### PR TITLE
Add James Peralta project entry

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -29,6 +29,17 @@
     "githubRepoLink": "https://github.com/issackj1/issackj1.github.io"
   },
   {
+    "title": "James Peralta",
+    "role": "Design & Full-stack Dev",
+    "techStack": [
+      "Webflow",
+      "Responsive Design"
+    ],
+    "description": "Redesigned the marketing site with a refreshed visual system, improved structure, and clear calls to action.",
+    "liveDemoLink": "https://jamesperalta.com",
+    "githubRepoLink": ""
+  },
+  {
     "title": "Meme Genius AI",
     "role": "Design & Full-stack Dev",
     "techStack": [


### PR DESCRIPTION
### Motivation
- Add a new portfolio item to showcase the redesigned marketing site at `https://jamesperalta.com` inside the project's data source.

### Description
- Insert a new project object for "James Peralta" into `data/projects.json` including `title`, `role`, `techStack` (`Webflow`, `Responsive Design`), a short `description`, and `liveDemoLink`.

### Testing
- Started the dev server with `npm run dev` and ran a Playwright script that captured a screenshot at `artifacts/james-peralta-project.png`, confirming the projects list rendered the new entry (initial selector attempts timed out but the final capture succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989fe2487908325ae84762267f0b223)